### PR TITLE
[Refactor] Face detected and face image size

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # NativeScript Yoonit Camera
 
-![Generic badge](https://img.shields.io/badge/version-v1.0.0-<COLOR>.svg) ![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)
+![Generic badge](https://img.shields.io/badge/version-v1.1.2-<COLOR>.svg) ![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)
 
 A NativeScript plugin to provide:
 - Modern Android Camera API (Camera X)
@@ -137,31 +137,33 @@ After that, you can access the camera object in your entire project using `this.
 ## API
 
 #### Methods  
-| Function | Parameters | Return Type | Valid values | Description |
-|-|-|-|-|-|  
-| **`requestPermission`** | - | promise | - | Ask to user to give the permission to access camera.
-| **`hasPermission`** | - | boolean | - | Return if application has camera permission.
-| **`preview`** | - | void | - | Start camera preview if has permission.
-| **`startCapture`** | `captureType: string` | void | `none` default capture type. `face` for face recognition. `barcode` to read barcode content. | Set capture type none, face or barcode.
-| **`stopCapture`** | - | void | - | Stop any type of capture.
-| **`toggleLens`** | - | void | - | Set camera lens facing front or back.
-| **`getLens`** | - | number | - | Return `number` that represents lens face state: 0 for front 1 for back camera.  
-| **`setFaceNumberOfImages`** | `faceNumberOfImages: number` | void | Any positive `number` value | Default value is 0. For value 0 is saved infinity images. When saved images reached the "face number os images", the `onEndCapture` is triggered.
-| **`setFaceDetectionBox`** |`faceDetectionBox: boolean` | void | `true` or `false` | Set to show face detection box when face detected.   
-| **`setFaceTimeBetweenImages`** | `faceTimeBetweenImages: number` | void | Any positive `number` that represent time in milli seconds | Set saving face images time interval in milli seconds.  
-| **`setFacePaddingPercent`** | `facePaddingPercent: number` | void | Any positive `number` value | Set face image and bounding box padding in percent.  
-| **`setFaceImageSize`** | `faceImageSize: number` | void | Any positive `number` value | Set face image size to be saved.    
+
+| Function                       | Parameters                      | Valid values                                                    | Return Type | Description
+|-                               | -                               | -                                                               | -           | -
+| **`requestPermission`**        | -                               | -                                                               | promise     | Ask to user to give the permission to access camera.
+| **`hasPermission`**            | -                               | -                                                               | boolean     | Return if application has camera permission.
+| **`preview`**                  | -                               | -                                                               | void        | Start camera preview if has permission.
+| **`startCapture`**             | `captureType: string`           | <ul><li>`"none"`</li><li>`"face"`</li><li>`"barcode"`</li></ul> | void        | Set capture type none, face or barcode.
+| **`stopCapture`**              | -                               | -                                                               | void        | Stop any type of capture.
+| **`toggleLens`**               | -                               | -                                                               | void        | Set camera lens facing front or back.
+| **`getLens`**                  | -                               | -                                                               | number      | Return `number` that represents lens face state: 0 for front 1 for back camera.  
+| **`setFaceNumberOfImages`**    | `faceNumberOfImages: number`    | Any positive `number` value                                     | void        | Default value is 0. For value 0 is saved infinity images. When saved images reached the "face number os images", the `onEndCapture` is triggered.
+| **`setFaceDetectionBox`**      |`faceDetectionBox: boolean`      | `true` or `false`                                               | void        | Set to show face detection box when face detected.   
+| **`setFaceTimeBetweenImages`** | `faceTimeBetweenImages: number` | Any positive `number` that represent time in milli seconds      | void        | Set saving face images time interval in milli seconds.  
+| **`setFacePaddingPercent`**    | `facePaddingPercent: number`    | Any positive `number` value                                     | void        | Set face image and bounding box padding in percent.  
+| **`setFaceImageSize`**         | `faceImageSize: number`         | Any positive `number` value                                     | void        | Set face image size to be saved.    
 
 
 #### Events  
-| Event | Parameters | Description |
-|-|-|-|
-| faceImage | `{ count: number, total: number, image: object = { path: string, source: blob } }` | Must have started capture type of face (see `startCapture`). Emitted when the face image file is created: <ul><li>count: current index</li><li>total: total to create</li><li>image.path: the face image path</li><li>image.source: the blob file</li><ul>
-| faceDetected | `{ faceDetected: boolean }` | Emitted `true` while the camera detects a face. Emitted `false` once when a face is no more detected    
-| endCapture | - | Emitted when the number of face image files created is equal of the number of images set (see the method `setFaceNumberOfImages`).   
-| qrCodeContent | `{ content: string }` | Must have started capture type of barcode (see `startCapture`). Emitted when the camera scan a QR Code.   
-| status |`{ type: 'error'/'message', status: string }` | Emitted message error from native. Used more often for debug purpose.   
-| permissionDenied | - | Emitted when try to `preview` but there is not camera permission.
+
+| Event            | Parameters                                                                         | Description 
+| -                | -                                                                                  | -
+| faceImage        | `{ count: number, total: number, image: object = { path: string, source: blob } }` | Must have started capture type of face. Emitted when the face image file is created: <ul><li>count: current index</li><li>total: total to create</li><li>image.path: the face image path</li><li>image.source: the blob file</li><ul>
+| faceDetected     | `{ x: number, y: number, width: number, height: number }`                          | Must have started capture type of face. Emit the detected face bounding box. Emit all parameters null if no more face detecting.    
+| endCapture       | -                                                                                  | Must have started capture type of face. Emitted when the number of face image files created is equal of the number of images set (see the method `setFaceNumberOfImages`).   
+| qrCodeContent    | `{ content: string }`                                                              | Must have started capture type of barcode (see `startCapture`). Emitted when the camera scan a QR Code.   
+| status           | `{ type: 'error'/'message', status: string }`                                      | Emit message error from native. Used more often for debug purpose.   
+| permissionDenied | -                                                                                  | Emit when try to `preview` but there is not camera permission.
 
 
 ## To contribute and make it better

--- a/demo-vue/app/components/App.vue
+++ b/demo-vue/app/components/App.vue
@@ -100,8 +100,9 @@
         }
       },
 
-      doFaceDetected({ faceDetected }) {
-        if (!faceDetected) {
+      doFaceDetected({ x, y, width, height }) {
+        console.log('[YooCamera] doFaceDetected', `(${x}, ${y}, ${width}, ${height})`)
+        if (!x || !y || !width || !height) {
           this.faceImagePath = null
         }
       },

--- a/demo-vue/package-lock.json
+++ b/demo-vue/package-lock.json
@@ -1279,13 +1279,6 @@
       "version": "file:../src",
       "requires": {
         "nativescript-permissions": "^1.3.8"
-      },
-      "dependencies": {
-        "nativescript-permissions": {
-          "version": "1.3.11",
-          "resolved": "https://registry.npmjs.org/nativescript-permissions/-/nativescript-permissions-1.3.11.tgz",
-          "integrity": "sha512-4ox9WpVJPLfepPauqECvPfbxVE1hVPVVBLZxOs3d9+2Yrr0mSkJO7D7BQ4OUS90hHfRdPhf70aJKWxzJoqi63g=="
-        }
       }
     },
     "abbrev": {

--- a/src/Yoonit.Camera.android.ts
+++ b/src/Yoonit.Camera.android.ts
@@ -84,8 +84,8 @@ export class YoonitCamera extends CameraBase {
         this.nativeView.setFacePaddingPercent(facePaddingPercent);
     }
 
-    public setFaceImageSize(faceImageSize: number): void {
-        this.nativeView.setFaceImageSize(faceImageSize);
+    public setFaceImageSize(width: number, height: number): void {
+        this.nativeView.setFaceImageSize(width, height);
     }
 
     public requestPermission(explanation: string = ''): Promise<boolean> {

--- a/src/Yoonit.Camera.android.ts
+++ b/src/Yoonit.Camera.android.ts
@@ -134,15 +134,33 @@ class CameraEventListener extends java.lang.Object implements ai.cyberlabs.yooni
         }
     }
 
-    public onFaceDetected(faceDetected: boolean): void {
+    public onFaceDetected(x: number, y: number, width: number, height: number): void {
         const owner = this.owner.get();
 
         if (owner) {
             owner.notify({
                 eventName: 'faceDetected',
                 object: owner,
-                faceDetected
+                x,
+                y,
+                width,
+                height
             } as FaceDetectedEventData);
+        }
+    }
+
+    public onFaceUndetected(): void {
+        const owner = this.owner.get();
+
+        if (owner) {
+            owner.notify({
+                eventName: 'faceDetected',
+                object: owner,
+                x: null,
+                y: null,
+                width: null,
+                height: null
+            } as EventData);
         }
     }
 

--- a/src/Yoonit.Camera.common.ts
+++ b/src/Yoonit.Camera.common.ts
@@ -45,7 +45,7 @@ export abstract class CameraBase extends ContentView implements CameraDefinition
 
   public setFacePaddingPercent(facePaddingPercent: number): void {}
 
-  public setFaceImageSize(faceImageSize: number): void {}
+  public setFaceImageSize(width: number, height: number): void {}
 
   public requestPermission(explanationText?: string): Promise<boolean> {
     return new Promise((resolve, reject) => resolve());

--- a/src/Yoonit.Camera.ios.ts
+++ b/src/Yoonit.Camera.ios.ts
@@ -170,15 +170,33 @@ class CameraEventListener extends NSObject implements CameraEventListenerDelegat
         }
     }
 
-    public onFaceDetectedWithFaceDetected(faceDetected: boolean): void {
+    public onFaceDetectedWithXYWidthHeight(x: number, y: number, width: number, height: number): void {
         const owner = this.owner.get();
 
         if (owner) {
             owner.notify({
                 eventName: 'faceDetected',
                 object: owner,
-                faceDetected
+                x,
+                y,
+                width,
+                height
             } as FaceDetectedEventData);
+        }
+    }
+
+    public onFaceUndetected(): void {
+        const owner = this.owner.get();
+
+        if (owner) {
+            owner.notify({
+                eventName: 'faceDetected',
+                object: owner,
+                x: null,
+                y: null,
+                width: null,
+                height: null
+            } as EventData);
         }
     }
 

--- a/src/Yoonit.Camera.ios.ts
+++ b/src/Yoonit.Camera.ios.ts
@@ -84,8 +84,8 @@ export class YoonitCamera extends CameraBase {
         this.nativeView.setFacePaddingPercentWithFacePaddingPercent(facePaddingPercent);
     }
 
-    public setFaceImageSize(faceImageSize: number) {
-        this.nativeView.setFaceImageSizeWithFaceImageSize(faceImageSize);
+    public setFaceImageSize(width: number, height: number) {
+        this.nativeView.setFaceImageSizeWithWidthHeight(width, height);
     }
 
     public requestPermission(explanation: string = ''): Promise<boolean> {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,7 +17,10 @@ export interface FaceImageCreatedEventData extends EventData {
 }
 
 export interface FaceDetectedEventData extends EventData {
-    faceDetected: boolean;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
 }
 
 export interface BarcodeScannedEventData extends EventData {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -43,7 +43,7 @@ export declare class Camera extends ContentView {
     setFaceDetectionBox(faceDetectionBox: boolean): void;
     setFaceTimeBetweenImages(faceTimeBetweenImages: number): void;
     setFacePaddingPercent(facePaddingPercent: number): void;
-    setFaceImageSize(faceImageSize: number): void;
+    setFaceImageSize(width: number, height: number): void;
 
     on(eventNames: string, callback: (data: EventData) => void, thisArg?: any);
     on(event: faceImage, callback: (args: FaceImageCreated) => void, thisArg?: any);

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@yoonit/nativescript-camera",
-	"version": "1.1.0",
+	"version": "1.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,13 +1,13 @@
 {
 	"name": "@yoonit/nativescript-camera",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "Yoonit Camera have a custom view that shows a preview layer of the front/back camera and detects human faces in it and read qr code.",
 	"main": "Yoonit.Camera",
 	"typings": "index.d.ts",
 	"nativescript": {
 		"platforms": {
-			"android": "1.0.0",
-			"ios": "1.0.0"
+			"android": "1.0.1",
+			"ios": "1.0.3"
 		}
 	},
 	"repository": {

--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -23,5 +23,5 @@ dependencies {
     implementation 'com.google.mlkit:face-detection:16.0.2'
     implementation 'com.google.mlkit:barcode-scanning:16.0.3'
 
-    implementation 'com.github.Yoonit-Labs:android-yoonit-camera:1.0.0'
+    implementation 'com.github.Yoonit-Labs:android-yoonit-camera:1.0.1'
 }

--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,4 +1,4 @@
-pod 'YoonitCamera', :git => "https://github.com/Yoonit-Labs/ios-yoonit-camera.git", :tag => '1.0.0'
+pod 'YoonitCamera', :git => "https://github.com/Yoonit-Labs/ios-yoonit-camera.git", :tag => '1.0.3'
 
 platform :ios, '12.0'
 

--- a/src/typings/android.d.ts
+++ b/src/typings/android.d.ts
@@ -76,7 +76,8 @@ declare module ai {
 					export class CameraEventListener {
 						public static class: java.lang.Class<ai.cyberlabs.yoonit.camera.interfaces.CameraEventListener>;
 						public onFaceImageCreated(param0: number, param1: number, param2: string): void;
-						public onFaceDetected(param0: boolean): void;
+						public onFaceDetected(param0: number, param1: number, param2: number, param3: number): void;
+						public onFaceUndetected(): void;
 						public onEndCapture(): void;
 						public onError(param0: string): void;
 						public onMessage(param0: string): void;

--- a/src/typings/android.d.ts
+++ b/src/typings/android.d.ts
@@ -38,7 +38,7 @@ declare module ai {
 					public setFaceDetectionBox(param0: Boolean): void;
 					public setFaceTimeBetweenImages(param0: number): void;
 					public setFacePaddingPercent(param0: number): void;
-					public setFaceImageSize(param0: number): void;
+					public setFaceImageSize(param0: number, param1: number): void;
 					public constructor(param0: globalAndroid.content.Context);
 				}
 				export module CameraView {

--- a/src/typings/objc!FaceTracker.d.ts
+++ b/src/typings/objc!FaceTracker.d.ts
@@ -51,7 +51,7 @@ declare class CameraView extends UIView {
 
     setFaceDetectionBoxWithFaceDetectionBox(faceDetectionBox: boolean): void;
 
-    setFaceImageSizeWithFaceImageSize(faceImageSize: number): void;
+    setFaceImageSizeWithWidthHeight(width: number, height: number): void;
 
     setFaceNumberOfImagesWithFaceNumberOfImages(faceNumberOfImages: number): void;
 

--- a/src/typings/objc!FaceTracker.d.ts
+++ b/src/typings/objc!FaceTracker.d.ts
@@ -7,7 +7,9 @@ interface CameraEventListenerDelegate {
 
     onFaceImageCreatedWithCountTotalImagePath(count: number, total: number, imagePath: string): void;
 
-    onFaceDetectedWithFaceDetected(faceDetected: boolean): void;
+    onFaceDetectedWithXYWidthHeight(x: number, y: number, width: number, height: number): void;
+
+    onFaceUndetected(): void;
 
     onEndCapture(): void;
 


### PR DESCRIPTION
Bump version from v1.1.1 to v1.1.2.
Update readme.
Update iOS and Android yoonit-camera version usage.

Refactor face detected events:
- change logic usage face events;
- emit the detected face bounding box event;
- add face undetected event for no more face is detecting. Internal usage to emit `faceDetected(null, null, null, null)`;

Refactor set face image size:
- Refactor set face image size;
